### PR TITLE
Fixed Typo!

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,12 @@ Scheduling non-essential work yourself is very difficult to do. It’s impossibl
 
 
 ```typescript
-import { IdlePreload, IdleModule } from '@angularclass/idle-preload';
+import { IdlePreload, IdlePreloadModule } from '@angularclass/idle-preload';
 
 @NgModule({
   bootstrap: [ App ],
   imports: [
-    IdleModule.forRoot(), // forRoot ensures the providers are only created once
+    IdlePreloadModule.forRoot(), // forRoot ensures the providers are only created once
     RouterModule.forRoot([], { useHash: false, preloadingStrategy: IdlePreload }),
   ]
 })


### PR DESCRIPTION
While trying to implement this library by following the instructions in README I got "/node_modules/@angularclass/idle-preload/dist/index"' has no exported member 'IdleModule'" error. Then I checked the source file and found this simple but confusing typo.