### PR TITLE
Checking internet connection & preload requirement

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,15 +39,31 @@ export class IdlePreload /*implements PreloadingStrategy*/ {
   * include zone to run outside of zone.js
   */
   constructor(private _ngZone: NgZone, @Inject(REQUEST_IDLE_CALLBACK) private requestIdleCallback: any) {}
-
- /*
-  * fire off preloading async modules
-  */
-  preload(route: /*Route*/ any, fn: any /* () => Observable<any>*/ ): any/* Observable<any> */ {
-    this.requestIdleCallback(fn);
-    return of(null);
+  loadingRoute = new Set<Route>();
+  loading = true;
+  
+  /*To avoid reloading the route*/
+  if (this.loadingRoute.has(route)) {
+    this.loading = false;
+  }
+  /*Checking for slow internet connection*/
+  const conn = typeof navigator !== 'undefined' ? (navigator as any).connection : undefined;
+  if (conn) {
+      if ((conn.effectiveType || '').includes('2g') || conn.saveData) { this.loading = false};
   }
 
+ /*
+  * fire off preloading async modules - loading only required modules
+  */
+  if (this.loading) {
+      if(route.data && !route.data.preload) {
+        return null;
+      } else {
+        preload(route: /*Route*/ any, fn: any /* () => Observable<any>*/ ): any/* Observable<any> */ {
+        this.requestIdleCallback(fn);
+        return of(null);
+      }
+ }
 }
 
 /*

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,10 +42,6 @@ export class IdlePreload /*implements PreloadingStrategy*/ {
   loadingRoute = new Set<Route>();
   loading = true;
   
-  /*To avoid reloading the route*/
-  if (this.loadingRoute.has(route)) {
-    this.loading = false;
-  }
   /*Checking for slow internet connection*/
   const conn = typeof navigator !== 'undefined' ? (navigator as any).connection : undefined;
   if (conn) {
@@ -53,18 +49,24 @@ export class IdlePreload /*implements PreloadingStrategy*/ {
   }
 
  /*
-  * fire off preloading async modules - loading only required modules
+  * fire off preloading async modules
   */
-  preload(route: /*Route*/ any, fn: any /* () => Observable<any>*/ ): any/* Observable<any> */ {
-    if(this.loading) {
-     if(route.data && !route.data.preload) {
+  if (this.loading) {
+    preload(route: /*Route*/ any, fn: any /* () => Observable<any>*/ ): any/* Observable<any> */ {
+      /*To avoid reloading the route*/
+      if (this.loadingRoute.has(route)) {
+        return null;
+      }
+      /*loading only required modules*/
+      if(route.data && !route.data.preload) {
         return null;
       } else {
         this.requestIdleCallback(fn);
         return of(null);
       }
     }
- }
+  }
+}
 
 /*
  * raw providers

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,16 +55,16 @@ export class IdlePreload /*implements PreloadingStrategy*/ {
  /*
   * fire off preloading async modules - loading only required modules
   */
-  if (this.loading) {
-      if(route.data && !route.data.preload) {
+  preload(route: /*Route*/ any, fn: any /* () => Observable<any>*/ ): any/* Observable<any> */ {
+    if(this.loading) {
+     if(route.data && !route.data.preload) {
         return null;
       } else {
-        preload(route: /*Route*/ any, fn: any /* () => Observable<any>*/ ): any/* Observable<any> */ {
         this.requestIdleCallback(fn);
         return of(null);
       }
+    }
  }
-}
 
 /*
  * raw providers


### PR DESCRIPTION
Modules which doesn't require preloading can be provided with data: {preload: false} in the route. Those modules will be avoided now.

 Internet connection checked before preloading. If the connection is on a 2G network or if the data saver is enabled, preloading will not be done.